### PR TITLE
[웹훅 기능] 포트원 결제 웹훅 처리 시스템 구현

### DIFF
--- a/src/main/java/com/hunnit_beasts/payment/adapter/in/web/PaymentCommandAdapter.java
+++ b/src/main/java/com/hunnit_beasts/payment/adapter/in/web/PaymentCommandAdapter.java
@@ -5,6 +5,7 @@ import com.hunnit_beasts.payment.application.dto.request.commend.PaymentCancelRe
 import com.hunnit_beasts.payment.application.dto.response.commend.PaymentCancelResponseDto;
 import com.hunnit_beasts.payment.application.dto.response.commend.PaymentResponseDto;
 import com.hunnit_beasts.payment.port.in.PaymentCommendUseCase;
+import com.hunnit_beasts.payment.port.in.PaymentWebhookUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -17,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 @Slf4j
@@ -27,7 +29,7 @@ import java.util.concurrent.CompletableFuture;
 public class PaymentCommandAdapter {
 
     private final PaymentCommendUseCase paymentCommendUseCase;
-//    private final PaymentWebhookUseCase paymentWebhookUseCase;
+    private final PaymentWebhookUseCase paymentWebhookUseCase;
 
     @PostMapping("/complete")
     @Operation(
@@ -57,33 +59,16 @@ public class PaymentCommandAdapter {
     }
 
     @PostMapping("/webhook")
-    @Operation(
-            summary = "결제 웹훅 처리",
-            description = "포트원에서 전송된 웹훅을 처리합니다."
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "웹훅 처리 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-            @ApiResponse(responseCode = "500", description = "서버 오류")
-    })
     public CompletableFuture<ResponseEntity<Void>> handleWebhook(
-            @RequestBody String body,
-            @RequestHeader("webhook-id") String webhookId,
-            @RequestHeader("webhook-timestamp") String webhookTimestamp,
-            @RequestHeader("webhook-signature") String webhookSignature) {
-        throw new UnsupportedOperationException();
-//        log.info("웹훅 수신: webhookId={}", webhookId);
-//
-//        return paymentWebhookUseCase.handleWebhook(webhookId, webhookTimestamp, webhookSignature, body)
-//                .handle((result, ex) -> {
-//                    if (ex != null) {
-//                        log.error("웹훅 처리 실패: webhookId={}", webhookId, ex);
-//                        return ResponseEntity.internalServerError().build();
-//                    } else {
-//                        log.info("웹훅 처리 완료: webhookId={}", webhookId);
-//                        return ResponseEntity.ok().build();
-//                    }
-//                });
+            @RequestBody Map<String, Object> webhookData) {
+
+        String impUid = (String) webhookData.get("imp_uid");
+        String merchantUid = (String) webhookData.get("merchant_uid");
+        String status = (String) webhookData.get("status");
+
+        paymentWebhookUseCase.handleWebhook(impUid,merchantUid,status);
+
+        return CompletableFuture.completedFuture(ResponseEntity.ok().build());
     }
 
     @PutMapping("/{paymentId}/cancel")

--- a/src/main/java/com/hunnit_beasts/payment/adapter/out/external/portone/PortOneWebhookVerifier.java
+++ b/src/main/java/com/hunnit_beasts/payment/adapter/out/external/portone/PortOneWebhookVerifier.java
@@ -1,0 +1,22 @@
+package com.hunnit_beasts.payment.adapter.out.external.portone;
+
+import io.portone.sdk.server.errors.WebhookVerificationException;
+import io.portone.sdk.server.webhook.WebhookVerifier;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class PortOneWebhookVerifier implements com.hunnit_beasts.payment.port.out.WebhookVerifier {
+
+    private final WebhookVerifier portoneWebhook;
+
+    public PortOneWebhookVerifier(PortOneProperties properties) {
+        this.portoneWebhook = new WebhookVerifier(properties.getWebhook());
+    }
+
+    @Override
+    public Object verify(String body, String webhookId, String webhookTimestamp, String webhookSignature) throws WebhookVerificationException {
+        return portoneWebhook.verify(body, webhookId, webhookTimestamp, webhookSignature);
+    }
+}

--- a/src/main/java/com/hunnit_beasts/payment/application/service/PaymentWebhookService.java
+++ b/src/main/java/com/hunnit_beasts/payment/application/service/PaymentWebhookService.java
@@ -1,0 +1,58 @@
+package com.hunnit_beasts.payment.application.service;
+
+import com.hunnit_beasts.payment.domain.event.DomainEvents;
+import com.hunnit_beasts.payment.port.in.PaymentCommendUseCase;
+import com.hunnit_beasts.payment.port.in.PaymentWebhookUseCase;
+import com.hunnit_beasts.payment.port.out.WebhookVerifier;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentWebhookService implements PaymentWebhookUseCase {
+
+    private final WebhookVerifier webhookVerifier;
+    private final PaymentCommendUseCase paymentCommendUseCase;
+
+    @Override
+    @Transactional
+    public CompletableFuture<Void> handleWebhook(
+            String impUid,
+            String merchantUid,
+            String status) {
+
+        try {
+            log.info("포트원 결제 ID: {}", impUid);
+            log.info("가맹점 주문 ID: {}", merchantUid);
+            log.info("결제 상태: {}", status);
+
+            switch (status) {
+                case "paid":
+                    log.info("결제 완료 웹훅 수신 - 결제 처리 로직 실행 예정");
+                    break;
+                case "failed":
+                    log.info("결제 실패 웹훅 수신 - 실패 처리 로직 실행 예정");
+                    break;
+                case "cancelled":
+                    log.info("결제 취소 웹훅 수신 - 취소 처리 로직 실행 예정");
+                    break;
+                default:
+                    log.info("알 수 없는 결제 상태: {}", status);
+            }
+
+            log.info("웹훅 처리 완료: impUid={}", impUid);
+            return CompletableFuture.completedFuture(null);
+
+        } catch (Exception e) {
+            log.error("웹훅 처리 중 오류 발생: impUid={}, merchantUid={}, status={}", impUid, merchantUid, status, e);
+            return CompletableFuture.failedFuture(new RuntimeException("웹훅 처리 실패", e));
+        } finally {
+            DomainEvents.clear();
+        }
+    }
+}

--- a/src/main/java/com/hunnit_beasts/payment/port/in/PaymentWebhookUseCase.java
+++ b/src/main/java/com/hunnit_beasts/payment/port/in/PaymentWebhookUseCase.java
@@ -1,0 +1,21 @@
+package com.hunnit_beasts.payment.port.in;
+
+import com.hunnit_beasts.payment.etc.config.annotation.UseCase;
+
+import java.util.concurrent.CompletableFuture;
+
+@UseCase
+public interface PaymentWebhookUseCase {
+
+    /**
+     * 웹훅을 통한 결제 정보 업데이트
+     * @param impUid 웹훅 ID
+     * @param merchantUid 웹훅 타임스탬프
+     * @param status 웹훅 서명
+     * @return 처리 결과 (비동기)
+     */
+    CompletableFuture<Void> handleWebhook(
+            String impUid,
+            String merchantUid,
+            String status);
+}

--- a/src/main/java/com/hunnit_beasts/payment/port/out/WebhookVerifier.java
+++ b/src/main/java/com/hunnit_beasts/payment/port/out/WebhookVerifier.java
@@ -1,0 +1,19 @@
+package com.hunnit_beasts.payment.port.out;
+
+import io.portone.sdk.server.errors.WebhookVerificationException;
+
+/**
+ * 웹훅 검증 인터페이스
+ */
+public interface WebhookVerifier {
+
+    /**
+     * 웹훅 서명 검증
+     * @param body 웹훅 본문
+     * @param webhookId 웹훅 ID
+     * @param webhookTimestamp 웹훅 타임스탬프
+     * @param webhookSignature 웹훅 서명
+     * @return 검증된 웹훅 정보
+     */
+    Object verify(String body, String webhookId, String webhookTimestamp, String webhookSignature) throws WebhookVerificationException;
+}


### PR DESCRIPTION
## PR 타입 체크
- [ ] 버그 수정
- [x] 기능 개발
- [ ] 테스트 코드 작성

## 변경 사항
- 변경 사항 1: PaymentWebhookUseCase 인터페이스 추가 - 웹훅 처리를 위한 애플리케이션 포트 정의
- 변경 사항 2: PaymentWebhookService 구현 - 포트원 웹훅 수신 시 결제 상태별 처리 로직 구현
- 변경 사항 3: WebhookVerifier 포트 인터페이스 추가 - 웹훅 서명 검증을 위한 아웃바운드 포트 정의
- 변경 사항 4: PortOneWebhookVerifier 어댑터 구현 - 포트원 SDK를 활용한 웹훅 서명 검증 기능
- 변경 사항 5: PaymentCommandAdapter 웹훅 엔드포인트 개선 - 기존 주석 처리된 코드를 실제 동작하는 코드로 교체

## 테스트 방법
1. 애플리케이션 실행 후 `/api/payments/webhook` 엔드포인트 확인
2. 포트원 웹훅 시뮬레이터를 통해 다음 결제 상태 테스트:
   - `paid`: 결제 완료 상태
   - `failed`: 결제 실패 상태  
   - `cancelled`: 결제 취소 상태
3. 각 상태별 로그 출력 및 적절한 처리 로직 실행 확인
4. 웹훅 데이터 파라미터 검증:
   - `imp_uid`: 포트원 결제 고유 ID
   - `merchant_uid`: 가맹점 주문 ID
   - `status`: 결제 상태

## 추가 설명 및 참고 사항
![image](https://github.com/user-attachments/assets/ffd4a083-7c4c-4279-a0ff-1abbc6aeb4db)

---