### PR TITLE
[리팩터링] 헥사고날 아키텍처 개선 - 외부 라이브러리 어댑터 분리

### DIFF
--- a/src/main/java/com/hunnit_beasts/payment/adapter/out/external/portone/PortOnePaymentClient.java
+++ b/src/main/java/com/hunnit_beasts/payment/adapter/out/external/portone/PortOnePaymentClient.java
@@ -1,5 +1,8 @@
 package com.hunnit_beasts.payment.adapter.out.external.portone;
 
+import com.hunnit_beasts.payment.domain.model.external.ExternalPaymentInfo;
+import com.hunnit_beasts.payment.port.out.PaymentClient;
+import io.portone.sdk.server.payment.PaidPayment;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -7,20 +10,37 @@ import java.util.concurrent.CompletableFuture;
 
 @Slf4j
 @Component
-public class PortOnePaymentClient implements com.hunnit_beasts.payment.port.out.PaymentClient {
+public class PortOnePaymentClient implements PaymentClient {
 
     private final io.portone.sdk.server.payment.PaymentClient portone;
 
     public PortOnePaymentClient(PortOneProperties properties) {
         this.portone = new io.portone.sdk.server.payment.PaymentClient(
-                properties.getApi(),  // API 시크릿
-                "https://api.portone.io",  // API 기본 URL
-                properties.getStoreId()  // 상점 ID
+                properties.getApi(),
+                "https://api.portone.io",
+                properties.getStoreId()
         );
     }
 
     @Override
-    public CompletableFuture<?> getPayment(String paymentId) {
-        return portone.getPayment(paymentId);
+    public CompletableFuture<ExternalPaymentInfo> getPayment(String paymentId) {
+        return portone.getPayment(paymentId)
+                .thenApply(payment -> {
+                    if (payment instanceof PaidPayment paidPayment) {
+                        log.info("PortOne 결제 정보 조회 성공: paymentId={}", paymentId);
+                        return new PortOnePaymentInfo(paidPayment);
+                    } else {
+                        log.warn("결제가 완료되지 않은 상태: paymentId={}, type={}",
+                                paymentId, payment.getClass().getSimpleName());
+                        throw new IllegalStateException("결제가 완료되지 않았습니다: " + paymentId);
+                    }
+                })
+                .handle((result, throwable) -> {
+                    if (throwable != null) {
+                        log.error("PortOne 결제 정보 조회 실패: paymentId={}", paymentId, throwable);
+                        throw new RuntimeException("결제 정보 조회 중 오류 발생: " + paymentId, throwable);
+                    }
+                    return result;
+                });
     }
 }

--- a/src/main/java/com/hunnit_beasts/payment/adapter/out/external/portone/PortOnePaymentInfo.java
+++ b/src/main/java/com/hunnit_beasts/payment/adapter/out/external/portone/PortOnePaymentInfo.java
@@ -1,0 +1,102 @@
+package com.hunnit_beasts.payment.adapter.out.external.portone;
+
+import com.hunnit_beasts.payment.domain.model.external.ExternalPaymentInfo;
+import io.portone.sdk.server.payment.PaidPayment;
+import lombok.RequiredArgsConstructor;
+
+import java.math.BigDecimal;
+
+/**
+ * PortOne의 PaidPayment를 도메인의 ExternalPaymentInfo로 변환하는 어댑터
+ * Anti-Corruption Layer 역할
+ */
+@RequiredArgsConstructor
+public class PortOnePaymentInfo implements ExternalPaymentInfo {
+
+    private final PaidPayment paidPayment;
+
+    @Override
+    public String getTransactionId() {
+        return paidPayment.getTransactionId();
+    }
+
+    @Override
+    public String getOrderName() {
+        return paidPayment.getOrderName();
+    }
+
+    @Override
+    public BigDecimal getTotalAmount() {
+        return BigDecimal.valueOf(paidPayment.getAmount().getTotal());
+    }
+
+    @Override
+    public String getReceiptUrl() {
+        return paidPayment.getReceiptUrl();
+    }
+
+    @Override
+    public String getPgProvider() {
+        return paidPayment.getChannel().getPgProvider().getValue();
+    }
+
+    @Override
+    public String getPgTxId() {
+        return paidPayment.getPgTxId();
+    }
+
+    @Override
+    public String getPaymentMethod() {
+        return extractPaymentMethod();
+    }
+
+    @Override
+    public String getPgResponse() {
+        return paidPayment.getPgResponse();
+    }
+
+    @Override
+    public boolean isPaymentCompleted() {
+        // PortOne의 PaidPayment는 이미 결제 완료된 상태
+        return true;
+    }
+
+    /**
+     * 결제 수단 정보 추출 (기존 PaymentDomainMapper 로직 활용)
+     */
+    private String extractPaymentMethod() {
+        String paymentMethod = "UNKNOWN";
+
+        try {
+            if (paidPayment.getMethod() != null) {
+                String methodStr = paidPayment.getMethod().toString();
+
+                if (methodStr.contains("provider=")) {
+                    int start = methodStr.indexOf("provider=") + 9;
+                    int end = methodStr.indexOf(",", start);
+                    if (end == -1) {
+                        end = methodStr.indexOf(")", start);
+                    }
+                    if (start > 9 && end > start) {
+                        paymentMethod = methodStr.substring(start, end);
+                    }
+                }
+            }
+
+            if ("UNKNOWN".equals(paymentMethod) && paidPayment.getPgResponse() != null) {
+                String pgResponse = paidPayment.getPgResponse();
+                if (pgResponse.contains("\"payMethod\": \"")) {
+                    int start = pgResponse.indexOf("\"payMethod\": \"") + 13;
+                    int end = pgResponse.indexOf("\"", start);
+                    if (start > 13 && end > start) {
+                        paymentMethod = pgResponse.substring(start, end);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            // 로깅은 어댑터 계층에서 처리
+        }
+
+        return "UNKNOWN".equals(paymentMethod) ? "Kakaopay" : paymentMethod;
+    }
+}

--- a/src/main/java/com/hunnit_beasts/payment/application/service/PaymentCommandService.java
+++ b/src/main/java/com/hunnit_beasts/payment/application/service/PaymentCommandService.java
@@ -3,28 +3,29 @@ package com.hunnit_beasts.payment.application.service;
 import com.hunnit_beasts.payment.application.dto.request.commend.PaymentCancelRequestDto;
 import com.hunnit_beasts.payment.application.dto.response.commend.PaymentCancelResponseDto;
 import com.hunnit_beasts.payment.application.dto.response.commend.PaymentResponseDto;
-import com.hunnit_beasts.payment.application.mapper.PaymentDomainMapper;
 import com.hunnit_beasts.payment.application.mapper.PaymentDtoMapper;
 import com.hunnit_beasts.payment.domain.event.DomainEvent;
 import com.hunnit_beasts.payment.domain.event.DomainEvents;
-import com.hunnit_beasts.payment.domain.event.payment.PaymentCompletedEvent;
-import com.hunnit_beasts.payment.domain.model.money.Money;
-import com.hunnit_beasts.payment.domain.model.payment.ExternalIdentifier;
+import com.hunnit_beasts.payment.domain.model.external.ExternalPaymentInfo;
 import com.hunnit_beasts.payment.domain.model.payment.Payment;
-import com.hunnit_beasts.payment.domain.model.payment.PaymentProcessingInfo;
+import com.hunnit_beasts.payment.domain.service.PaymentDomainService;
 import com.hunnit_beasts.payment.port.in.PaymentCommendUseCase;
 import com.hunnit_beasts.payment.port.out.DomainEventPublisher;
 import com.hunnit_beasts.payment.port.out.PaymentClient;
 import com.hunnit_beasts.payment.port.out.PaymentPersistencePort;
-import io.portone.sdk.server.payment.PaidPayment;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * 결제 커맨드 애플리케이션 서비스
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -32,9 +33,9 @@ public class PaymentCommandService implements PaymentCommendUseCase {
 
     private final PaymentClient paymentClient;
     private final PaymentPersistencePort persistencePort;
-    private final DomainEventPublisher eventPublisher;
+    private final DomainEventPublisher eventPublisher; // 기존 DomainEventPublisher 사용
     private final PaymentDtoMapper paymentDtoMapper;
-    private final PaymentDomainMapper paymentDomainMapper;
+    private final PaymentDomainService paymentDomainService;
 
     @Override
     public PaymentCancelResponseDto cancelPayment(String paymentId, PaymentCancelRequestDto request) {
@@ -42,71 +43,111 @@ public class PaymentCommandService implements PaymentCommendUseCase {
     }
 
     @Override
-    @Transactional
     public CompletableFuture<PaymentResponseDto> completePayment(String externalIdentifier) {
-        Payment existingPayment = persistencePort.findByIdentifier(externalIdentifier)
-                .orElse(null);
+        log.info("결제 완료 처리 시작: {}", externalIdentifier);
 
-        if (existingPayment != null && existingPayment.isCompleted())
+        // 1. 빠른 중복 체크
+        Payment existingPayment = findExistingPaymentQuickCheck(externalIdentifier);
+        if (existingPayment != null && existingPayment.isCompleted()) {
+            log.info("이미 완료된 결제: {}", externalIdentifier);
             return CompletableFuture.completedFuture(paymentDtoMapper.toResponseDto(existingPayment));
+        }
 
-        // 포트원 API로 결제 정보 조회
+        // 2. 외부 API 호출 후 트랜잭션 처리
         return paymentClient.getPayment(externalIdentifier)
-                .thenApply(payment -> {
-                    if (payment instanceof PaidPayment paidPayment) {
-                        Payment completedPayment = processPayment(externalIdentifier, paidPayment);
-
-                        List<DomainEvent> events = DomainEvents.collectEvents();
-                        eventPublisher.publishAll(events);
-
-                        return paymentDtoMapper.toResponseDto(completedPayment);
-                    } else
-                        throw new IllegalStateException("결제가 완료되지 않았습니다: " + externalIdentifier);
+                .thenApply(externalPaymentInfo -> {
+                    log.info("외부 결제 정보 조회 완료: {}", externalIdentifier);
+                    return executePaymentProcessing(externalIdentifier, externalPaymentInfo);
                 })
                 .exceptionally(e -> {
-                    throw new RuntimeException("결제 정보 조회 중 오류 발생", e);
+                    log.error("결제 완료 처리 실패: {}", externalIdentifier, e);
+                    throw new RuntimeException("결제 완료 처리 중 오류: " + externalIdentifier, e);
                 });
     }
 
-    /**
-     * 결제 정보 처리 (생성 또는 업데이트)
-     */
-    private Payment processPayment(String externalIdentifier, PaidPayment paidPayment) {
-        Payment payment = persistencePort.findByIdentifier(externalIdentifier)
-                .orElseGet(() -> createNewPayment(externalIdentifier, paidPayment));
-
-        Payment completedPayment = payment.complete(
-                paidPayment.getReceiptUrl(),
-                paidPayment.getPgResponse()
-        );
-
-        if (completedPayment != payment) {
-            DomainEvents.publish(new PaymentCompletedEvent(
-                    completedPayment.getId(),
-                    ExternalIdentifier.of(externalIdentifier),
-                    Money.won((int) paidPayment.getAmount().getTotal())
-            ));
-
-            return persistencePort.save(completedPayment);
-        }
-
-        return payment;
+    @Transactional(readOnly = true)
+    public Payment findExistingPaymentQuickCheck(String externalIdentifier) {
+        return persistencePort.findByIdentifier(externalIdentifier).orElse(null);
     }
 
     /**
-     * 새 결제 정보 생성
+     * 트랜잭션 안에서 결제 처리 + 이벤트 발행 스케줄링
      */
-    private Payment createNewPayment(String externalIdentifier, PaidPayment paidPayment) {
-        PaymentProcessingInfo processingInfo = paymentDomainMapper.mapToProcessingInfo(paidPayment);
+    @Transactional
+    public PaymentResponseDto executePaymentProcessing(
+            String externalIdentifier,
+            ExternalPaymentInfo externalPaymentInfo) {
 
-        Payment payment = Payment.createFromPortone(
-                externalIdentifier,
-                paidPayment.getOrderName(),
-                (int) paidPayment.getAmount().getTotal(),
-                processingInfo,
-                paidPayment.getPgResponse()
-        );
+        try {
+            log.debug("결제 처리 트랜잭션 시작: {}", externalIdentifier);
 
-        return persistencePort.save(payment);
+            // 1. 최신 상태 조회
+            Payment currentPayment = persistencePort.findByIdentifier(externalIdentifier)
+                    .orElse(null);
+
+            // 2. 도메인 로직 처리
+            Payment processedPayment = paymentDomainService.completePayment(
+                    currentPayment,
+                    externalIdentifier,
+                    externalPaymentInfo
+            );
+
+            // 3. 영속화
+            Payment savedPayment = persistencePort.save(processedPayment);
+
+            // 4. 트랜잭션 커밋 후 이벤트 발행 스케줄링
+            scheduleEventPublishingAfterCommit();
+
+            log.info("결제 처리 완료: {}", externalIdentifier);
+            return paymentDtoMapper.toResponseDto(savedPayment);
+
+        } catch (Exception e) {
+            log.error("결제 처리 실패: {}", externalIdentifier, e);
+            DomainEvents.clear();
+            throw e;
+        }
+    }
+
+    /**
+     * 트랜잭션 커밋 후 이벤트 발행 스케줄링
+     * Spring의 TransactionSynchronization을 활용
+     */
+    private void scheduleEventPublishingAfterCommit() {
+        List<DomainEvent> events = DomainEvents.collectEvents();
+        if (events.isEmpty()) {
+            return;
+        }
+
+        log.debug("트랜잭션 커밋 후 이벤트 발행 예약: {} 개", events.size());
+
+        // Spring의 트랜잭션 동기화 기능 활용
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            log.info("트랜잭션 커밋 완료 - 도메인 이벤트 발행 시작: {} 개", events.size());
+                            try {
+                                // 기존 DomainEventPublisher 사용!
+                                eventPublisher.publishAll(events);
+                                log.debug("도메인 이벤트 발행 완료");
+                            } catch (Exception e) {
+                                log.error("도메인 이벤트 발행 실패", e);
+                            }
+                        }
+
+                        @Override
+                        public void afterCompletion(int status) {
+                            if (status == STATUS_ROLLED_BACK) {
+                                log.warn("트랜잭션 롤백됨 - 이벤트 발행 취소");
+                            }
+                        }
+                    }
+            );
+        } else {
+            // 트랜잭션이 없는 경우 즉시 발행 (fallback)
+            log.warn("트랜잭션 동기화가 비활성화됨 - 즉시 이벤트 발행");
+            eventPublisher.publishAll(events);
+        }
     }
 }

--- a/src/main/java/com/hunnit_beasts/payment/domain/model/external/ExternalPaymentInfo.java
+++ b/src/main/java/com/hunnit_beasts/payment/domain/model/external/ExternalPaymentInfo.java
@@ -1,0 +1,54 @@
+package com.hunnit_beasts.payment.domain.model.external;
+
+import java.math.BigDecimal;
+
+/**
+ * 외부 결제 시스템의 정보를 추상화한 인터페이스
+ */
+public interface ExternalPaymentInfo {
+
+    /**
+     * 트랜잭션 ID 반환
+     */
+    String getTransactionId();
+
+    /**
+     * 주문명 반환
+     */
+    String getOrderName();
+
+    /**
+     * 결제 금액 반환
+     */
+    BigDecimal getTotalAmount();
+
+    /**
+     * 영수증 URL 반환
+     */
+    String getReceiptUrl();
+
+    /**
+     * PG 제공자 반환
+     */
+    String getPgProvider();
+
+    /**
+     * PG 트랜잭션 ID 반환
+     */
+    String getPgTxId();
+
+    /**
+     * 결제 수단 반환
+     */
+    String getPaymentMethod();
+
+    /**
+     * PG 응답 정보 반환 (JSON)
+     */
+    String getPgResponse();
+
+    /**
+     * 결제가 성공적으로 완료되었는지 확인
+     */
+    boolean isPaymentCompleted();
+}

--- a/src/main/java/com/hunnit_beasts/payment/domain/service/PaymentDomainService.java
+++ b/src/main/java/com/hunnit_beasts/payment/domain/service/PaymentDomainService.java
@@ -1,0 +1,112 @@
+package com.hunnit_beasts.payment.domain.service;
+
+import com.hunnit_beasts.payment.domain.event.DomainEvents;
+import com.hunnit_beasts.payment.domain.event.payment.PaymentCompletedEvent;
+import com.hunnit_beasts.payment.domain.model.external.ExternalPaymentInfo;
+import com.hunnit_beasts.payment.domain.model.money.Money;
+import com.hunnit_beasts.payment.domain.model.payment.ExternalIdentifier;
+import com.hunnit_beasts.payment.domain.model.payment.Payment;
+import com.hunnit_beasts.payment.domain.model.payment.PaymentProcessingInfo;
+import org.springframework.stereotype.Component;
+
+/**
+ * 결제 도메인 서비스
+ * 복잡한 비즈니스 로직을 캡슐화하고 도메인 규칙을 강제함
+ */
+@Component
+public class PaymentDomainService {
+
+    /**
+     * 외부 결제 정보를 바탕으로 결제를 완료 처리
+     *
+     * @param existingPayment 기존 결제 정보 (null 가능)
+     * @param externalIdentifier 외부 식별자
+     * @param externalPaymentInfo 외부 결제 정보
+     * @return 처리된 결제 정보
+     */
+    public Payment completePayment(
+            Payment existingPayment,
+            String externalIdentifier,
+            ExternalPaymentInfo externalPaymentInfo) {
+
+        // 결제가 이미 완료된 경우 기존 결제 반환
+        if (existingPayment != null && existingPayment.isCompleted()) {
+            return existingPayment;
+        }
+
+        // 기존 결제가 없으면 새로 생성
+        Payment payment = existingPayment != null
+                ? existingPayment
+                : createNewPayment(externalIdentifier, externalPaymentInfo);
+
+        // 결제 완료 처리
+        Payment completedPayment = payment.complete(
+                externalPaymentInfo.getReceiptUrl(),
+                externalPaymentInfo.getPgResponse()
+        );
+
+        // 상태가 변경된 경우에만 이벤트 발행
+        if (completedPayment != payment) {
+            publishPaymentCompletedEvent(completedPayment, externalIdentifier, externalPaymentInfo);
+        }
+
+        return completedPayment;
+    }
+
+    /**
+     * 새로운 결제 생성
+     * 외부 결제 정보를 바탕으로 도메인 객체 생성
+     */
+    public Payment createNewPayment(String externalIdentifier, ExternalPaymentInfo externalPaymentInfo) {
+        validateExternalPaymentInfo(externalPaymentInfo);
+
+        PaymentProcessingInfo processingInfo = PaymentProcessingInfo.of(
+                externalPaymentInfo.getTransactionId(),
+                externalPaymentInfo.getPgProvider(),
+                externalPaymentInfo.getPgTxId(),
+                externalPaymentInfo.getPaymentMethod()
+        );
+
+        return Payment.createFromPortone(
+                externalIdentifier,
+                externalPaymentInfo.getOrderName(),
+                externalPaymentInfo.getTotalAmount().intValue(),
+                processingInfo,
+                externalPaymentInfo.getPgResponse()
+        );
+    }
+
+    /**
+     * 결제 완료 이벤트 발행
+     */
+    private void publishPaymentCompletedEvent(
+            Payment completedPayment,
+            String externalIdentifier,
+            ExternalPaymentInfo externalPaymentInfo) {
+
+        DomainEvents.publish(new PaymentCompletedEvent(
+                completedPayment.getId(),
+                ExternalIdentifier.of(externalIdentifier),
+                Money.won(externalPaymentInfo.getTotalAmount().intValue())
+        ));
+    }
+
+    /**
+     * 외부 결제 정보 유효성 검증
+     */
+    private void validateExternalPaymentInfo(ExternalPaymentInfo externalPaymentInfo) {
+        if (!externalPaymentInfo.isPaymentCompleted()) {
+            throw new IllegalStateException("결제가 완료되지 않은 상태입니다");
+        }
+
+        if (externalPaymentInfo.getTotalAmount() == null ||
+                externalPaymentInfo.getTotalAmount().signum() <= 0) {
+            throw new IllegalArgumentException("유효하지 않은 결제 금액입니다");
+        }
+
+        if (externalPaymentInfo.getOrderName() == null ||
+                externalPaymentInfo.getOrderName().trim().isEmpty()) {
+            throw new IllegalArgumentException("주문명이 없습니다");
+        }
+    }
+}

--- a/src/main/java/com/hunnit_beasts/payment/port/out/PaymentClient.java
+++ b/src/main/java/com/hunnit_beasts/payment/port/out/PaymentClient.java
@@ -1,5 +1,7 @@
 package com.hunnit_beasts.payment.port.out;
 
+import com.hunnit_beasts.payment.domain.model.external.ExternalPaymentInfo;
+
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -12,5 +14,5 @@ public interface PaymentClient {
      * @param paymentId 결제 ID
      * @return 결제 정보 (비동기)
      */
-    CompletableFuture<?> getPayment(String paymentId);
+    CompletableFuture<ExternalPaymentInfo> getPayment(String paymentId);
 }


### PR DESCRIPTION
<!--
  제목: [작업한 기능/수정 사항] 간단한 설명
-->
## PR 타입 체크
- [ ] 버그 수정
- [x] 기능 개발
- [ ] 테스트 코드 작성

## 변경 사항
- **외부 결제 API 모델 분리**: 외부 결제 정보를 처리하는 `ExternalPaymentInfo` 도메인 모델을 새로 추가하여 외부 시스템 의존성을 도메인에서 분리
- **PaymentClient 인터페이스 개선**: 반환 타입을 `ExternalPaymentInfo`로 변경하여 외부 API 응답을 도메인 모델로 캡슐화
- **PortOne 어댑터 확장**: `PortOnePaymentInfo` 클래스를 추가하여 포트원 API 응답을 도메인 모델로 변환하는 어댑터 패턴 구현
- **PaymentCommandService 리팩터링**: 외부 API 호출 로직을 어댑터로 분리하고 도메인 서비스와의 협력 구조 개선
- **도메인 서비스 신설**: `PaymentDomainService`를 새로 추가하여 도메인 로직을 캡슐화하고 어플리케이션 계층의 복잡성 감소

## 관련 이슈
- 참고: 헥사고날 아키텍처의 엄격한 적용을 통한 외부 의존성 격리

## 테스트 방법
1. **결제 생성 API 테스트**
   - 기존 결제 생성 요청이 정상적으로 처리되는지 확인
   - 외부 API 호출이 새로운 어댑터를 통해 정상 동작하는지 검증
2. **도메인 모델 변환 테스트**
   - 외부 API 응답이 `ExternalPaymentInfo` 도메인 모델로 정확히 변환되는지 확인
   - 어댑터 패턴이 올바르게 동작하는지 검증
3. **헥사고날 아키텍처 준수 테스트**
   - 도메인 계층이 외부 라이브러리에 직접 의존하지 않는지 확인
   - 포트와 어댑터가 명확히 분리되었는지 검증

## 추가 설명 및 참고 사항
- **아키텍처 개선**: 이번 리팩터링을 통해 어플리케이션 계층에서 외부 라이브러리 의존성을 완전히 제거하고, 모든 외부 시스템과의 통신을 어댑터 계층으로 격리했습니다.
- **도메인 순수성 확보**: 도메인 모델인 `ExternalPaymentInfo`를 통해 외부 API 응답을 도메인 언어로 변환하여 비즈니스 로직의 순수성을 확보했습니다.
- **확장성 향상**: 새로운 결제 서비스를 추가할 때 어댑터만 구현하면 되므로 시스템의 확장성이 크게 향상되었습니다.
- **테스트 용이성**: 외부 의존성이 인터페이스로 추상화되어 단위 테스트 작성이 더욱 용이해졌습니다.

---
> **주의:**  
> - 이 변경은 헥사고날 아키텍처의 핵심 원칙을 엄격히 적용한 중요한 리팩터링입니다.  
> - 외부 의존성 격리를 통해 도메인 로직의 순수성과 테스트 가능성이 크게 향상되었으니 코드 리뷰 시 아키텍처 관점에서 검토해 주세요.